### PR TITLE
Make CloudFront invalidation optional in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,4 +64,8 @@ jobs:
         run: |
           cd apps/web
           aws s3 sync dist/ s3://chronicle-sync-web/ --delete
-          aws cloudfront create-invalidation --distribution-id ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID }} --paths "/*"
+          if [ ! -z "${{ secrets.CLOUDFRONT_DISTRIBUTION_ID }}" ]; then
+            aws cloudfront create-invalidation --distribution-id ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID }} --paths "/*"
+          else
+            echo "Skipping CloudFront invalidation as CLOUDFRONT_DISTRIBUTION_ID is not set"
+          fi


### PR DESCRIPTION
This PR makes the CloudFront invalidation step optional in the release workflow:

- Add conditional check for CLOUDFRONT_DISTRIBUTION_ID secret
- Skip invalidation if secret is not set
- Add informative message when skipping

This change prevents the workflow from failing when the CloudFront distribution ID is not configured, making it easier to set up the project without AWS CloudFront.