### PR TITLE
Remove CloudFront from deployment workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,8 +60,7 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: us-east-1
 
-      - name: Deploy web interface
+      - name: Deploy web interface to S3
         run: |
           cd apps/web
           aws s3 sync dist/ s3://chronicle-sync-web/ --delete
-          aws cloudfront create-invalidation --distribution-id ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID }} --paths "/*"


### PR DESCRIPTION
This PR simplifies the web deployment by removing CloudFront:

- Remove CloudFront invalidation step
- Keep only S3 deployment
- Reduce required AWS permissions

After this change:
1. The web interface will be deployed directly to S3
2. No CloudFront distribution ID is needed
3. The website will be available at `http://chronicle-sync-web.s3-website-[region].amazonaws.com`

This makes the setup simpler and requires fewer AWS permissions.