### PR TITLE
Fix TypeScript build issues

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19089,7 +19089,9 @@
         "ws": "^8.16.0"
       },
       "devDependencies": {
+        "@testing-library/jest-dom": "^6.6.3",
         "@types/crypto-js": "^4.2.1",
+        "@types/jest": "^29.5.14",
         "@types/ws": "^8.5.10",
         "typescript": "^5.3.3"
       }

--- a/packages/sync/package.json
+++ b/packages/sync/package.json
@@ -14,7 +14,9 @@
     "ws": "^8.16.0"
   },
   "devDependencies": {
+    "@testing-library/jest-dom": "^6.6.3",
     "@types/crypto-js": "^4.2.1",
+    "@types/jest": "^29.5.14",
     "@types/ws": "^8.5.10",
     "typescript": "^5.3.3"
   }

--- a/packages/sync/tsconfig.json
+++ b/packages/sync/tsconfig.json
@@ -9,7 +9,8 @@
       "./src/types",
       "./node_modules/@types",
       "../../node_modules/@types"
-    ]
+    ],
+    "types": ["node"]
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "**/*.test.ts"]


### PR DESCRIPTION
This PR fixes the TypeScript build issues by:

- Adding missing dependencies in sync package
- Overriding TypeScript types configuration to exclude test types during build

The changes ensure that:
1. All required dependencies are properly installed
2. TypeScript compilation works correctly for the sync package
3. Test-related type definitions do not interfere with the production build