### PR TITLE
Fix Chrome Web Store authentication using service account

### DIFF
--- a/infrastructure/ci/deploy-extensions.sh
+++ b/infrastructure/ci/deploy-extensions.sh
@@ -7,9 +7,19 @@ CHROME_STORE_ITEM_ID=$3
 AMO_JWT_ISSUER=$4
 AMO_JWT_SECRET=$5
 
+# Install required dependencies
+npm install --no-save google-auth-library
+npm install -g web-ext
+
+# Get access token from service account credentials
+export GOOGLE_APPLICATION_CREDENTIALS=$(mktemp)
+echo "$CHROME_STORE_TOKEN" > "$GOOGLE_APPLICATION_CREDENTIALS"
+ACCESS_TOKEN=$(node infrastructure/ci/get-chrome-token.js)
+rm "$GOOGLE_APPLICATION_CREDENTIALS"
+
 if [ "$BRANCH" = "refs/heads/main" ]; then
   # Production: Upload to main store channels
-  curl -H "Authorization: Bearer $CHROME_STORE_TOKEN" \
+  curl -H "Authorization: Bearer $ACCESS_TOKEN" \
        -H "x-goog-api-version: 2" \
        -X PUT -T chronicle-sync-chrome.zip \
        "https://www.googleapis.com/upload/chromewebstore/v1.1/items/$CHROME_STORE_ITEM_ID"
@@ -19,7 +29,7 @@ if [ "$BRANCH" = "refs/heads/main" ]; then
     --api-secret="$AMO_JWT_SECRET"
 else
   # Staging: Upload to beta channels
-  curl -H "Authorization: Bearer $CHROME_STORE_TOKEN" \
+  curl -H "Authorization: Bearer $ACCESS_TOKEN" \
        -H "x-goog-api-version: 2" \
        -X PUT -T chronicle-sync-chrome.zip \
        "https://www.googleapis.com/upload/chromewebstore/v1.1/items/$CHROME_STORE_ITEM_ID"

--- a/infrastructure/ci/get-chrome-token.js
+++ b/infrastructure/ci/get-chrome-token.js
@@ -1,0 +1,12 @@
+const { GoogleAuth } = require('google-auth-library');
+
+async function getAccessToken() {
+  const auth = new GoogleAuth({
+    scopes: ['https://www.googleapis.com/auth/chromewebstore']
+  });
+  const client = await auth.getClient();
+  const token = await client.getAccessToken();
+  console.log(token.token);
+}
+
+getAccessToken().catch(console.error);


### PR DESCRIPTION
This PR fixes the Chrome Web Store authentication by:

1. Adding a new script to convert service account JSON to OAuth token
2. Installing required dependencies (google-auth-library and web-ext)
3. Using the correct OAuth token in the curl commands

This should resolve the authentication errors in the deployment workflow.