### PR TITLE
Replace store deployment with GitHub releases

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -87,15 +87,26 @@ jobs:
         run: |
           infrastructure/ci/build-extensions.sh "$VERSION" "$SYNC_URL"
       
-      - name: Deploy extensions
+      - name: Upload extension artifacts
         if: env.SHOULD_DEPLOY == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: browser-extensions
+          path: |
+            chronicle-sync-chrome.zip
+            chronicle-sync-firefox.zip
+          
+      - name: Create GitHub Release
+        if: env.SHOULD_DEPLOY == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
-          infrastructure/ci/deploy-extensions.sh \
-            "${{ github.ref }}" \
-            "${{ secrets.CHROME_STORE_TOKEN }}" \
-            "${{ secrets.CHROME_STORE_ITEM_ID }}" \
-            "${{ secrets.AMO_JWT_ISSUER }}" \
-            "${{ secrets.AMO_JWT_SECRET }}"
+          # Create a new release
+          gh release create "v${{ env.VERSION }}" \
+            --title "Release v${{ env.VERSION }}" \
+            --notes "Browser extensions for Chronicle Sync v${{ env.VERSION }}" \
+            chronicle-sync-chrome.zip \
+            chronicle-sync-firefox.zip
       
       - name: Deploy web interface
         if: env.SHOULD_DEPLOY == 'true'

--- a/infrastructure/ci/deploy-extensions.sh
+++ b/infrastructure/ci/deploy-extensions.sh
@@ -8,12 +8,20 @@ AMO_JWT_ISSUER=$4
 AMO_JWT_SECRET=$5
 
 # Install required dependencies
+command -v jq >/dev/null 2>&1 || {
+    echo "Installing jq..."
+    apt-get update && apt-get install -y jq
+}
 npm install --no-save google-auth-library
 npm install -g web-ext
 
 # Get access token from service account credentials
 export GOOGLE_APPLICATION_CREDENTIALS=$(mktemp)
-echo "$CHROME_STORE_TOKEN" > "$GOOGLE_APPLICATION_CREDENTIALS"
+# Format JSON properly with jq
+echo "$CHROME_STORE_TOKEN" | jq '.' > "$GOOGLE_APPLICATION_CREDENTIALS" || {
+    echo "Failed to parse JSON credentials. Make sure CHROME_STORE_TOKEN contains valid JSON"
+    exit 1
+}
 
 # Debug: Check if JSON is valid
 if ! jq . "$GOOGLE_APPLICATION_CREDENTIALS" > /dev/null 2>&1; then


### PR DESCRIPTION
This PR changes how we handle extension deployment:

1. Removes Chrome Web Store and Firefox Add-ons deployment (until extensions are approved)
2. Adds GitHub Release creation with extension packages
3. Adds workflow artifacts for both Chrome and Firefox extensions

This allows us to:
- Test extensions locally
- Share with beta testers
- Submit to stores manually when ready

The extensions will be available:
1. As artifacts in each workflow run (Actions tab > Run > Artifacts)
2. In GitHub Releases (Code tab > Releases)