### PR TITLE
Fix worker build configuration

### DIFF
--- a/webpack.worker.js
+++ b/webpack.worker.js
@@ -1,0 +1,31 @@
+const path = require('path');
+
+module.exports = {
+  target: 'webworker',
+  entry: './src/backend/index.js',
+  output: {
+    filename: 'worker.js',
+    path: path.resolve(__dirname, 'dist-worker')
+  },
+  mode: process.env.NODE_ENV || 'production',
+  module: {
+    rules: [
+      {
+        test: /\.js$/,
+        exclude: /node_modules/,
+        use: {
+          loader: 'babel-loader',
+          options: {
+            presets: [
+              ['@babel/preset-env', {
+                targets: {
+                  node: '18'
+                }
+              }]
+            ]
+          }
+        }
+      }
+    ]
+  }
+};


### PR DESCRIPTION
This PR adds proper webpack configuration for the Cloudflare Worker:

**Changes:**
- Added webpack.worker.js for worker-specific build
- Configured proper target and output
- Added babel configuration for Node.js 18

**Testing:**
1. Build worker:
   ```bash
   npm run build:worker
   ```
2. Deploy:
   ```bash
   npm run deploy:staging
   npm run deploy:prod
   ```