### PR TITLE
Fix worker build and deployment configuration

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,22 +24,26 @@ jobs:
     - name: Install dependencies
       run: npm ci
     
-    - name: Build
+    - name: Build extension
       run: npm run build
     
+    - name: Build worker
+      run: |
+        npx webpack --config webpack.worker.js --mode production
+    
     - name: Install Wrangler
-      run: npm install -g wrangler
+      run: npm install -g wrangler@latest
     
     - name: Deploy to Staging
       if: github.ref == 'refs/heads/staging'
-      run: npm run deploy:staging
+      run: wrangler deploy --env staging
       env:
         CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
         CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
     
     - name: Deploy to Production
       if: github.ref == 'refs/heads/main'
-      run: npm run deploy:prod
+      run: wrangler deploy --env production
       env:
         CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
         CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}


### PR DESCRIPTION
This PR updates the worker build and deployment configuration:

**Changes:**
- Update to use latest wrangler with `wrangler@latest`
- Switch from deprecated `wrangler publish` to `wrangler deploy`
- Build worker directly with webpack in the workflow
- Remove dependency on npm scripts for worker build

**Testing:**
1. Build worker:
   ```bash
   npx webpack --config webpack.worker.js --mode production
   ```
2. Deploy:
   ```bash
   wrangler deploy --env staging
   wrangler deploy --env production
   ```