### PR TITLE
Add environment variables to staging and production deployments

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -40,6 +40,8 @@ jobs:
       env:
         CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
         CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        STAGING_KV_ID: ${{ secrets.STAGING_KV_ID }}
+        STAGING_DB_ID: ${{ secrets.STAGING_DB_ID }}
     
     - name: Deploy to Production
       if: github.ref == 'refs/heads/main'
@@ -47,6 +49,8 @@ jobs:
       env:
         CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
         CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        PROD_KV_ID: ${{ secrets.PROD_KV_ID }}
+        PROD_DB_ID: ${{ secrets.PROD_DB_ID }}
     
     - name: Package Extension
       run: |


### PR DESCRIPTION
This PR adds the necessary environment variables to both staging and production deployments in the GitHub Actions workflow:

- Added `STAGING_KV_ID` and `STAGING_DB_ID` to staging deployment
- Added `PROD_KV_ID` and `PROD_DB_ID` to production deployment

These variables are required by wrangler.toml for proper deployment to Cloudflare Workers.