### PR TITLE
Pass Cloudflare IDs via wrangler --var flags

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -36,14 +36,20 @@ jobs:
     
     - name: Deploy to Staging
       if: github.ref == 'refs/heads/staging'
-      run: wrangler deploy --env staging
+      run: |
+        wrangler deploy --env staging \
+          --var "KV_NAMESPACE_ID:${{ secrets.STAGING_KV_ID }}" \
+          --var "D1_DB_ID:${{ secrets.STAGING_DB_ID }}"
       env:
         CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
         CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
     
     - name: Deploy to Production
       if: github.ref == 'refs/heads/main'
-      run: wrangler deploy --env production
+      run: |
+        wrangler deploy --env production \
+          --var "KV_NAMESPACE_ID:${{ secrets.PROD_KV_ID }}" \
+          --var "D1_DB_ID:${{ secrets.PROD_DB_ID }}"
       env:
         CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
         CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -13,11 +13,9 @@ bucket_name = "chronicle-sync-staging"
 [[env.staging.d1_databases]]
 binding = "DB"
 database_name = "chronicle-sync-staging"
-database_id = "${STAGING_DB_ID}"
 
 [[env.staging.kv_namespaces]]
 binding = "SYNC_KV"
-id = "${STAGING_KV_ID}"
 
 [env.production]
 name = "chronicle-sync"
@@ -30,8 +28,6 @@ bucket_name = "chronicle-sync"
 [[env.production.d1_databases]]
 binding = "DB"
 database_name = "chronicle-sync"
-database_id = "${PROD_DB_ID}"
 
 [[env.production.kv_namespaces]]
 binding = "SYNC_KV"
-id = "${PROD_KV_ID}"


### PR DESCRIPTION
This PR updates how we handle Cloudflare IDs (KV namespace and D1 database) by:

1. Removing environment variable references from wrangler.toml
2. Passing the IDs directly to wrangler using `--var` flags

This approach has several advantages:
- Cleaner wrangler.toml without environment variable references
- More explicit about what values are being passed
- Values are passed directly to wrangler instead of relying on environment variable substitution

Make sure to have the following secrets set in your GitHub repository:
- `STAGING_KV_ID`: Your staging KV namespace ID
- `STAGING_DB_ID`: Your staging D1 database ID
- `PROD_KV_ID`: Your production KV namespace ID
- `PROD_DB_ID`: Your production D1 database ID