### PR TITLE
Update Cloudflare configuration with proper variable handling

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -43,8 +43,6 @@ jobs:
       env:
         CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
         CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-        STAGING_KV_ID: ${{ secrets.STAGING_KV_ID }}
-        STAGING_DB_ID: ${{ secrets.STAGING_DB_ID }}
     
     - name: Deploy to Production
       if: github.ref == 'refs/heads/main'
@@ -55,8 +53,6 @@ jobs:
       env:
         CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
         CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-        PROD_KV_ID: ${{ secrets.PROD_KV_ID }}
-        PROD_DB_ID: ${{ secrets.PROD_DB_ID }}
     
     - name: Package Extension
       run: |

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -13,9 +13,11 @@ bucket_name = "chronicle-sync-staging"
 [[env.staging.d1_databases]]
 binding = "DB"
 database_name = "chronicle-sync-staging"
+database_id = "D1_DB_ID"
 
 [[env.staging.kv_namespaces]]
 binding = "SYNC_KV"
+id = "KV_NAMESPACE_ID"
 
 [env.production]
 name = "chronicle-sync"
@@ -28,6 +30,8 @@ bucket_name = "chronicle-sync"
 [[env.production.d1_databases]]
 binding = "DB"
 database_name = "chronicle-sync"
+database_id = "D1_DB_ID"
 
 [[env.production.kv_namespaces]]
 binding = "SYNC_KV"
+id = "KV_NAMESPACE_ID"


### PR DESCRIPTION
This PR updates how we handle Cloudflare IDs (KV namespace and D1 database) by:

1. Using placeholder variable names in wrangler.toml (`KV_NAMESPACE_ID` and `D1_DB_ID`)
2. Passing the actual values via `--var` flags in the GitHub Actions workflow
3. Removing redundant environment variables since we are using `--var` flags

This approach ensures that:
- wrangler.toml has all required fields with placeholder values
- The actual IDs are passed at runtime via `--var` flags
- No environment variable interpolation is needed

Make sure to have the following secrets set in your GitHub repository:
- `STAGING_KV_ID`: Your staging KV namespace ID
- `STAGING_DB_ID`: Your staging D1 database ID
- `PROD_KV_ID`: Your production KV namespace ID
- `PROD_DB_ID`: Your production D1 database ID