### PR TITLE
Update worker to use ES modules format

### DIFF
--- a/scripts/generate-wrangler-config.sh
+++ b/scripts/generate-wrangler-config.sh
@@ -25,6 +25,10 @@ name = "chronicle-sync"
 main = "dist-worker/worker.js"
 compatibility_date = "2023-12-01"
 
+# Use module format for D1 compatibility
+compatibility_flags = ["nodejs_compat"]
+format = "modules"
+
 [env.staging]
 name = "chronicle-sync-staging"
 vars = { ENVIRONMENT = "staging" }

--- a/src/backend/index.js
+++ b/src/backend/index.js
@@ -15,7 +15,7 @@ CREATE TABLE IF NOT EXISTS devices (
 `;
 
 export default {
-  async fetch(request, env) {
+  async fetch(request, env, ctx) {
     try {
       const url = new URL(request.url);
       const path = url.pathname;

--- a/webpack.worker.js
+++ b/webpack.worker.js
@@ -5,7 +5,13 @@ module.exports = {
   entry: './src/backend/index.js',
   output: {
     filename: 'worker.js',
-    path: path.resolve(__dirname, 'dist-worker')
+    path: path.resolve(__dirname, 'dist-worker'),
+    library: {
+      type: 'module'
+    }
+  },
+  experiments: {
+    outputModule: true
   },
   mode: process.env.NODE_ENV || 'production',
   module: {


### PR DESCRIPTION
This PR updates the worker to use ES modules format which is required for D1 compatibility. Changes include:

- Update webpack config to output ES modules
- Add module format configuration to wrangler.toml
- Update worker code to use proper ES module exports
- Add nodejs_compat flag for better compatibility