### PR TITLE
Fix screenshot paths in CI workflow and E2E tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,13 +68,14 @@ jobs:
       - name: Run E2E tests and generate screenshots
         if: success()
         run: |
-          mkdir -p tests/screenshots/setup-flow
+          mkdir -p docs/screenshots/setup-flow
           xvfb-run --auto-servernum npm run test:e2e
         env:
           CI: true
           DISPLAY: :99
           CHROME_PATH: /usr/bin/google-chrome
           SCREENSHOTS_FOR_DOCS: true
+          SCREENSHOT_DIR: docs/screenshots
 
       - name: Upload test artifacts
         if: always()  # Changed from failure() to always() to preserve screenshots
@@ -82,7 +83,7 @@ jobs:
         with:
           name: test-artifacts
           path: |
-            tests/screenshots/**/*.png
+            docs/screenshots/**/*.png
             tests/logs/
           retention-days: 14
           if-no-files-found: ignore

--- a/tests/extension.e2e.test.js
+++ b/tests/extension.e2e.test.js
@@ -43,7 +43,9 @@ describe('Extension End-to-End Test', () => {
   beforeAll(async () => {
     // Create screenshots directory only if needed
     if (process.env.SCREENSHOTS_FOR_DOCS) {
-      screenshotDir = path.join(__dirname, 'screenshots', 'setup-flow');
+      screenshotDir = process.env.SCREENSHOT_DIR
+        ? path.join(process.env.SCREENSHOT_DIR, 'setup-flow')
+        : path.join(__dirname, 'screenshots', 'setup-flow');
       await fs.mkdir(screenshotDir, { recursive: true });
     }
 


### PR DESCRIPTION
This PR fixes the screenshot paths in the CI workflow and E2E tests to ensure screenshots are properly saved and deployed to GitHub Pages.

Changes:
1. Update CI workflow to save screenshots directly to docs/screenshots
2. Update E2E tests to use SCREENSHOT_DIR environment variable
3. Add .gitkeep file to ensure docs/screenshots directory exists
4. Update artifact paths to match new screenshot location