### PR TITLE
Fix screenshot URLs to use custom domain chroniclesync.xyz

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,8 +116,8 @@ jobs:
               for img in "$dir"/*.png; do
                 if [ -f "$img" ]; then
                   name=$(basename "$img")
-                  # Use GitHub Pages URL for screenshots
-                  pages_url="https://posix4e.github.io/chronicle-sync/screenshots/$test_name/$name"
+                  # Use custom domain URL for screenshots
+                  pages_url="https://chroniclesync.xyz/screenshots/$test_name/$name"
                   echo "#### ${name%.png}" >> docs/test-results.md
                   echo "![${name%.png}]($pages_url)" >> docs/test-results.md
                   echo "" >> docs/test-results.md


### PR DESCRIPTION
This PR fixes the screenshot URLs to use the custom domain chroniclesync.xyz instead of github.io.

The previous PR used github.io URLs, but the site is actually deployed to chroniclesync.xyz. This PR updates the URLs to use the correct domain.

After this change, screenshot links will point to `https://chroniclesync.xyz/screenshots/...` instead of `https://posix4e.github.io/chronicle-sync/screenshots/...`